### PR TITLE
Doppelte if-Abfrage entfernt

### DIFF
--- a/Classes/Queue/QueueManager.php
+++ b/Classes/Queue/QueueManager.php
@@ -69,11 +69,7 @@ class QueueManager
      */
     public function setContent($content)
     {
-        $content        = (is_array($content) && count($content)) ? trim(implode("\n", $content)) : $content;
-        // is $content an empty array?
-        if (is_array($content) && count($content) == 0) {
-            $content = "";
-        }
+        $content        = (is_array($content) && count($content)) ? trim(implode("\n", $content)) : "";
         $this->content  = $content;
     }
 


### PR DESCRIPTION
Die doppelte if-Abfragen macht keinen Sinn. Es kann einfach in Zeile 72 das `$content` am Ende durch einen Leerstring ersetzt werden.